### PR TITLE
dev is merged to master on 2020.1.14

### DIFF
--- a/backend/certificate/verifier.py
+++ b/backend/certificate/verifier.py
@@ -59,9 +59,7 @@ def verifier_crt(post):
             return Response(data={'error': 'Keys or value are wrong'}, 
                                    status=status.HTTP_400_BAD_REQUEST)
 
-        if not key_exist_valid(request.data.dict(), 'obj', str) and \
-           not key_exist_valid(request.data.dict(), 'obj', 
-                files.uploadedfile.InMemoryUploadedFile):
+        if not key_exist_valid(request.data.dict(), 'obj', files.uploadedfile.InMemoryUploadedFile):
 
                 return Response(data={'error': 'Keys or value are wrong'}, 
                                     status=status.HTTP_400_BAD_REQUEST)  
@@ -87,8 +85,7 @@ def verifier_crt_sign(post):
                 return Response(data={'error': 'Keys or value are wrong'}, status=status.HTTP_400_BAD_REQUEST)
 
         if not key_exist_valid(request.FILES, 'req', files.uploadedfile.InMemoryUploadedFile):
-            if not key_exist_valid(request.data.dict(), 'req', str):
-                return Response(data={'error': 'Keys or value are wrong'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(data={'error': 'Keys or value are wrong'}, status=status.HTTP_400_BAD_REQUEST)
 
         return post(self, request)
 

--- a/backend/certificate/views.py
+++ b/backend/certificate/views.py
@@ -44,7 +44,8 @@ class CertificateParsing(APIView):
                 })  
                 res =  obj.request(is_object=False)
 
-        except:
+        except ValueError as e:
+            logger.error(e)
             return Response(data={'error': 'certificate or request content should be broken'}, 
                             status=status.HTTP_400_BAD_REQUEST)
                             

--- a/backend/certificate/views.py
+++ b/backend/certificate/views.py
@@ -22,12 +22,8 @@ class CertificateParsing(APIView):
     def post(self, request):
         obj_bytes = b''
 
-        if isinstance(request.data.dict().get('obj'), str):
-            obj_bytes = request.data.dict().get('obj').encode()
-
-        else:
-            for chunk in request.data.dict().get('obj').chunks():
-                obj_bytes += chunk
+        for chunk in request.data.dict().get('obj').chunks():
+            obj_bytes += chunk
 
         try:
             if request.data.dict().get('type') == 'crt':
@@ -71,12 +67,8 @@ class CertificateSigning(APIView):
     def post(self, request):
         req_bytes = b''
 
-        if isinstance(request.data.dict().get('req'), str):
-            req_bytes = request.data.dict().get('req').encode()
-
-        else:
-            for chunk in request.data.dict().get('req').chunks():
-                req_bytes += chunk            
+        for chunk in request.data.dict().get('req').chunks():
+            req_bytes += chunk            
 
         try:
             crt = SignCertificate({

--- a/backend/certificate/x509.py
+++ b/backend/certificate/x509.py
@@ -116,11 +116,17 @@ class ReadRequest(CertificateRequest):
         if not subject:
             subject = {'req_bytes': b'', 'req_codec': ''}
             
-        self.req = x509.load_pem_x509_csr(subject['req_bytes'], default_backend()) or \
-                    x509.load_der_x509_csr(subject['req_bytes'], default_backend())
+        if subject['req_codec'] == 'pem':
+            self.req = x509.load_pem_x509_csr(subject['req_bytes'], default_backend())
+
+        elif subject['req_codec'] == 'der':
+            self.req = x509.load_der_x509_csr(subject['req_bytes'], default_backend())
+
+        else:
+            raise('request codec {} is not supported'.format(subject['req_codec']))
         
         logger.debug('Certificate signing request format is {}'.format(subject['req_codec']))
-        logger.debug('Certificate signing request is:\n{}'.format(subject['req_bytes'].decode()))
+        logger.debug('Certificate signing request is:\n{}'.format(subject['req_bytes']))
 
         CertificateRequest.__init__(self, self.req)
 
@@ -150,11 +156,17 @@ class ReadCertificate(CertificateRequest):
         if not subject:
             subject = {'crt_bytes': b'', 'crt_codec': ''}
             
-        self.crt = x509.load_pem_x509_certificate(subject['crt_bytes'], default_backend()) or \
-                    x509.load_der_x509_certificate(subject['crt_bytes'], default_backend())
+        if subject['crt_codec'] == 'pem':    
+            self.crt = x509.load_pem_x509_certificate(subject['crt_bytes'], default_backend()) 
+
+        elif subject['crt_codec'] == 'der':
+            self.crt = x509.load_der_x509_certificate(subject['crt_bytes'], default_backend())
+
+        else:
+            raise ValueError('certificate codec {} is not supported'.format(subject['crt_codec']))                    
         
         logger.debug('Certificate format is {}'.format(subject['crt_codec']))
-        logger.debug('Certificate is:\n{}'.format(subject['crt_bytes'].decode()))
+        logger.debug('Certificate is:\n{}'.format(subject['crt_bytes']))
 
         CertificateRequest.__init__(self, self.crt)
 

--- a/frontend/src/views/CertificateParsing.vue
+++ b/frontend/src/views/CertificateParsing.vue
@@ -3,11 +3,7 @@
   <el-col :span="16">
     <el-form :model="form" :rules="rules" ref="form" status-icon label-width="180px">
       <h3>Request or Certificate</h3>	
-      <div class="subject">    
-        <el-form-item label="Browser local">
-          <el-switch v-model="form.subject.upload"></el-switch>
-        </el-form-item>       
-
+      <div class="subject">       
         <el-form-item label="Type">
           <el-select v-model="form.subject.type">
             <el-option label="Certificate Signing Request" value="req"></el-option>
@@ -22,7 +18,7 @@
           </el-select>
         </el-form-item>
 
-        <el-form-item v-if="form.subject.upload" label="File">
+        <el-form-item label="File">
           <el-upload class="upload-demo" drag action=""
             :auto-upload="false"
             :multiple="false"
@@ -34,10 +30,6 @@
             <div class="el-upload__text">Drop file here or <em>click to upload</em></div>
           </el-upload>
         </el-form-item>
-
-        <el-form-item v-else label="Content" prop="content">
-          <el-input type="textarea" rows=10 v-model="form.subject.obj"></el-input>
-        </el-form-item>  
       </div>
 
       <div class="submit">
@@ -54,29 +46,14 @@
 export default {
   name: 'CertificateSigning',
   data () {
-    // var validateContent = (rule, value, callback) => {
-    //   if (!value) { 
-    //     return callback(new Error('Empty not be allowed')) 
-    //   }
-    //   else {
-    //     callback();
-    //   }
-    // } 
-
 		return {
       form: {
         subject: {
-          upload: false,
           filelist: [],     
           type: 'crt',     
           codec: 'pem',
-          obj: null
+          obj: ''
         }
-      },  
-      rules: {
-        // content: [
-        //   {validator: validateContent, trigger: 'change'},
-        // ]
       }
     }
   },

--- a/frontend/src/views/CertificateParsing.vue
+++ b/frontend/src/views/CertificateParsing.vue
@@ -18,7 +18,7 @@
         <el-form-item label="Codec">
           <el-select v-model="form.subject.codec">
             <el-option label="PEM/Base64" value="pem"></el-option>
-            <el-option label="DER" value="der" disabled></el-option>
+            <el-option label="DER" value="der"></el-option>
           </el-select>
         </el-form-item>
 

--- a/frontend/src/views/CertificateSigning.vue
+++ b/frontend/src/views/CertificateSigning.vue
@@ -32,11 +32,7 @@
       </div>
 
       <h3>Request</h3>	
-      <div class="subject">    
-        <el-form-item label="Browser local">
-          <el-switch v-model="form.subject.upload"></el-switch>
-        </el-form-item>       
-
+      <div class="subject">     
         <el-form-item label="Request Codec">
           <el-select v-model="form.subject.codec">
             <el-option label="PEM/Base64" value="pem"></el-option>
@@ -44,7 +40,7 @@
           </el-select>
         </el-form-item>
 
-        <el-form-item v-if="form.subject.upload" label="Request File">
+        <el-form-item label="Request File">
           <el-upload class="upload-demo" drag action=""
             :auto-upload="false"
             :multiple="false"
@@ -56,10 +52,6 @@
             <div class="el-upload__text">Drop file here or <em>click to upload</em></div>
           </el-upload>
         </el-form-item>
-
-        <el-form-item v-else label="Request Content">
-          <el-input type="textarea" rows=10 v-model="form.subject.obj"></el-input>
-        </el-form-item>  
       </div>
 
       <div class="submit">
@@ -85,10 +77,9 @@ export default {
 					is_ca: false
         },
         subject: {
-          upload: false,
           filelist: [],          
           codec: 'pem',
-          obj: null
+          obj: ''
         }
       }  
     }

--- a/frontend/src/views/CertificateSigning.vue
+++ b/frontend/src/views/CertificateSigning.vue
@@ -40,7 +40,7 @@
         <el-form-item label="Request Codec">
           <el-select v-model="form.subject.codec">
             <el-option label="PEM/Base64" value="pem"></el-option>
-            <el-option label="DER" value="der" disabled></el-option>
+            <el-option label="DER" value="der"></el-option>
           </el-select>
         </el-form-item>
 


### PR DESCRIPTION
add feature
(1)API '/certificate/parsing' key 'codec' support 'der'
(2)API '/certificate/signing' key 'req_codec' support 'der'


remove actions:
(1)API '/certificate/parsing' key 'obj' value type doesn't support 'string', must be 'file'
(2)API '/certificate/signing' key 'req_bytes' value type doesn't support 'string', must be 'file'

